### PR TITLE
removed redundant bits of code

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ node ./node_modules/.bin/istanbul cover test.js
 Alternatively you can insert the line
 
 ```json
-"coverage": "node ./node_modules/.bin/istanbul cover test.js"
+"coverage": "istanbul cover ./test.js"
 ```
 
 into the scripts section of your `package.json` and run

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Learn how to use istanbul for tracking test/code coverage in your JS projects",
   "main": "test.js",
   "scripts": {
-    "coverage": "node ./node_modules/.bin/istanbul cover ./test.js",
+    "coverage": "istanbul cover ./test.js",
     "test": "node ./node_modules/.bin/istanbul cover mischief.js"
   },
   "repository": {


### PR DESCRIPTION
Favouring KISS principle, there is no need for `node ./node_modules/.bin/` in `package.json`.  
And here is why:
1. Scripts configured in `package.json` auto execute binaries from `./node_modules/.bin`
2. `./node_modules/.bin/istanbul` is an executable node script, no need to prefix it with `node`
